### PR TITLE
Adding npm version in engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
 	"version": "1.0.0",
 	"description": "Find Raids In GBF",
 	"engines": {
-		"node": "8.1.2"
+		"node": "8.1.2",
+		"npm": "5.2.x"
 	},
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Heroku redeployment with version > 5.2.0 will fail the build process